### PR TITLE
Modified to make compatible with Unifi Cloudkey installation

### DIFF
--- a/scripts/uwsgi.ini
+++ b/scripts/uwsgi.ini
@@ -10,10 +10,13 @@ home = %(base)/.env
 pythonpath = %(base)
 
 #socket file's location
-socket = /usr/share/nginx/spotipo/uwsgi.sock
+#socket = /usr/share/nginx/spotipo/uwsgi.sock
 
 #permissions for the socket file
-chmod-socket    = 666
+#chmod-socket    = 666
+
+http-socket = 127.0.0.1:9999
+#fastcgi-socket = /usr/share/nginx/spotipo/fastcgi.sock
 
 #the variable that holds a flask application inside the module imported at line #6
 callable = app
@@ -28,4 +31,3 @@ buffer-size=65535
 #issue with multiple uwsgi workers and flask-sqlalchemy
 lazy-apps = true
 workers = 2
-

--- a/scripts/wifiapp.conf
+++ b/scripts/wifiapp.conf
@@ -16,8 +16,9 @@ server {
     location / { try_files $uri @spotipo; }
 
     location @spotipo {
-        include uwsgi_params;
-        uwsgi_pass unix:/usr/share/nginx/spotipo/uwsgi.sock;
+#        include uwsgi_params;
+	include fastcgi.conf;
+        fastcgi_pass unix:/usr/share/nginx/spotipo/uwsgi.sock;
     }
 
     location /static {


### PR DESCRIPTION
Use http server and http-proxy rather than uwsgi socket due to Cloudkey using nginx-light with no uwsgi support.
Use a different port than default port 80/443 to not interfere with Cloudkey interfaces.
